### PR TITLE
Custom eV/Å force units in the GUI

### DIFF
--- a/nomad/units/default_en.txt
+++ b/nomad/units/default_en.txt
@@ -204,6 +204,7 @@ force_kilogram = g_0 * kilogram = pond
 force_gram = g_0 * gram = gf = gram_force
 force_metric_ton = g_0 * metric_ton = tf = metric_ton_force = force_t = t_force
 atomic_unit_of_force = E_h / a_0 = a_u_force
+force_eV_over_A = electron_volt / angstrom = eV_over_Å
 
 # Energy
 [energy] = [force] * [length]


### PR DESCRIPTION
I added eV/A force units. They are displayed correctly both in Units widget and in Geometry Optimization (see images).
However, I was not able to verify if the conversion to Newtons and other units works properly.
I will try to figure out how to set it as default later.

![custom_eV_A_force_1](https://github.com/ondracka/nomad/assets/106664429/8fc557b9-85b9-4ffc-ae00-53b5be125926)
![custom_eV_A_force_2](https://github.com/ondracka/nomad/assets/106664429/3d167f2a-9f1e-49f8-848f-b894ef1ea922)
